### PR TITLE
Prevent ExMplayer from messing up powersaving settings

### DIFF
--- a/src/inhibitor.h
+++ b/src/inhibitor.h
@@ -45,6 +45,8 @@ public:
  private:
 
     int _systemType;
+    bool _dpmsEnabled;
+    bool _screenSvrEnabled;
     uint _inhibitCookie;
      QPointer<QDBusInterface> interfaceScreenSvr;
 
@@ -54,7 +56,8 @@ public:
 
     void dectectSystem();
     int checkProcess(const char* name);
-
+    bool checkDpms();
+    bool checkScreenSvr();
 
 };
 


### PR DESCRIPTION
We need to check if DPMS and screensaver are enabled when ExMplayer starts. Inhibitor::deactivateInhibit() shouldn't enable them if they were disabled by user